### PR TITLE
Fix issue: bulk counter feature cannot compile on platforms having no sai_bulk_object_get_stats/sai_bulk_object_clear_stats

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -207,6 +207,8 @@ AC_MSG_ERROR("SAI headers API version and library version mismatch")])])
 CXXFLAGS="$SAVED_FLAGS"
 ])])
 
+AC_CHECK_FUNCS(sai_bulk_object_clear_stats sai_bulk_object_get_stats)
+
 AC_OUTPUT(Makefile
           meta/Makefile
           lib/Makefile

--- a/syncd/VendorSai.cpp
+++ b/syncd/VendorSai.cpp
@@ -661,6 +661,7 @@ sai_status_t VendorSai::bulkGetStats(
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
+#ifdef HAVE_SAI_BULK_OBJECT_GET_STATS
     return sai_bulk_object_get_stats(
             switchId,
             object_type,
@@ -671,6 +672,9 @@ sai_status_t VendorSai::bulkGetStats(
             mode,
             object_statuses,
             counters);
+#else
+    return SAI_STATUS_NOT_IMPLEMENTED;
+#endif
 }
 
 sai_status_t VendorSai::bulkClearStats(
@@ -687,6 +691,7 @@ sai_status_t VendorSai::bulkClearStats(
     SWSS_LOG_ENTER();
     VENDOR_CHECK_API_INITIALIZED();
 
+#ifdef HAVE_SAI_BULK_OBJECT_CLEAR_STATS
     return sai_bulk_object_clear_stats(
             switchId,
             object_type,
@@ -696,6 +701,9 @@ sai_status_t VendorSai::bulkClearStats(
             counter_ids,
             mode,
             object_statuses);
+#else
+    return SAI_STATUS_NOT_IMPLEMENTED;
+#endif
 }
 
 // BULK QUAD OID


### PR DESCRIPTION
Why I did this?

bulk counter feature uses two new SAI API sai_bulk_object_get_stats/sai_bulk_object_clear_stats. Some vendors have no such API implemented in their SAI code. Need a way to make compilation pass.

How I fix this?

1. Add AC_CHECK_FUNCS for sai_bulk_object_get_stats/sai_bulk_object_clear_stats which generates macro HAVE_SAI_BULK_OBJECT_CLEAR_STATS/HAVE_SAI_BULK_OBJECT_GET_STATS in config.h.
2. Use ifdef to avoid compilation failure.