### PR TITLE
[fastboot] Notify SAI that fastboot is done

### DIFF
--- a/syncd/Syncd.cpp
+++ b/syncd/Syncd.cpp
@@ -3822,7 +3822,8 @@ sai_status_t Syncd::processNotifySyncd(
             m_asicInitViewMode = false;
 
             if (m_commandLineOptions->m_startType == SAI_START_TYPE_FASTFAST_BOOT ||
-                m_commandLineOptions->m_startType == SAI_START_TYPE_EXPRESS_BOOT)
+                m_commandLineOptions->m_startType == SAI_START_TYPE_EXPRESS_BOOT ||
+                m_commandLineOptions->m_startType == SAI_START_TYPE_FAST_BOOT)
             {
                 // express/fastfast boot configuration end
 


### PR DESCRIPTION
**Why I did this**

Notify SAI that fastboot is done

**How I did this**

Set SAI_SWITCH_ATTR_FAST_API_ENABLE to false when fastboot is done

**How I verify this**

Manual test